### PR TITLE
Use configurable Redis in help view

### DIFF
--- a/config-example.ini
+++ b/config-example.ini
@@ -19,6 +19,9 @@ cors_policy.origins = http://0.0.0.0:8080
 redis.sessions.secret = 12342C48
 redis.sessions.timeout = 86400
 
+redis.help.host = localhost
+redis.help.port = 6379
+
 install_path = %(here)s
 model_data_dir = models
 locations_dir = %(here)s/location_files

--- a/webgnome_api/views/help.py
+++ b/webgnome_api/views/help.py
@@ -86,8 +86,8 @@ def create_help_feedback(request):
     json_request['ts'] = int(time.time())
 
     # find redis using redis sessions config
-    rhost = request.registry.settings['redis.sessions.host']
-    rport = request.registry.settings.get('redis.sessions.port', 6379)
+    rhost = request.registry.settings.get('redis.help.host', 'localhost')
+    rport = request.registry.settings.get('redis.help.port', 6379)
 
     client = redis.Redis(host=rhost, port=rport)
 

--- a/webgnome_api/views/help.py
+++ b/webgnome_api/views/help.py
@@ -84,7 +84,12 @@ def create_help_feedback(request):
         raise cors_exception(request, HTTPBadRequest)
 
     json_request['ts'] = int(time.time())
-    client = redis.Redis('localhost')
+
+    # find redis using redis sessions config
+    rhost = request.registry.settings['redis.sessions.host']
+    rport = request.registry.settings.get('redis.sessions.port', 6379)
+
+    client = redis.Redis(host=rhost, port=rport)
 
     if 'index' not in json_request:
         json_request['index'] = client.incr('index')


### PR DESCRIPTION
Having this hardcoded to `localhost` was messing up my Dockerized setup, so I made it configurable.  I'm re-using the `redis.sessions.host` configuration as that's likely the same instance of Redis that will be used, although technically it should probably be it's own configuration element.  Let me know if you'd like this to be updated.
